### PR TITLE
494 tinymce prevent tags from being pasted into the text editor

### DIFF
--- a/app/GEN/settings.py
+++ b/app/GEN/settings.py
@@ -432,7 +432,7 @@ logging.config.dictConfig(
 USE_SOCIAL_AUTH = os.getenv("USE_SOCIAL_AUTH", "False") == "True"
 USE_SOCIAL_AUTH_ONLY = os.getenv("USE_SOCIAL_AUTH_ONLY", "False") == "True"
 SOCIAL_AUTH_PROVIDERS = os.getenv("SOCIAL_AUTH_PROVIDERS").split(",")
-SOCIALACCOUNT_ADAPTER = 'accounts.adapter.CustomSocialAccountAdapter'
+SOCIALACCOUNT_ADAPTER = "accounts.adapter.CustomSocialAccountAdapter"
 # SOCIALACCOUNT_PROVIDERS = ast.literal_eval(os.getenv("SOCIAL_AUTH"))
 SOCIALACCOUNT_PROVIDERS = {
     "google": {
@@ -474,12 +474,12 @@ TINYMCE_DEFAULT_CONFIG = {
     "custom_undo_redo_levels": 20,
     # 'theme': 'modern',
     "plugins": """
-            save link image media preview codesample
+            paste save link image media preview codesample
             table code lists fullscreen insertdatetime searchreplace wordcount visualblocks
             visualchars code autolink lists charmap print anchor
             """,
     "toolbar1": """
-            fullscreen | bold italic underline | styleselect | fontsizeselect |
+            paste | fullscreen | bold italic underline | styleselect | fontsizeselect |
             forecolor | alignleft aligncenter alignright alignjustify | indent outdent |
             bullist numlist table | link image media | codesample |
             visualblocks visualchars | charmap hr pagebreak nonbreaking anchor | insertdatetime |
@@ -489,6 +489,8 @@ TINYMCE_DEFAULT_CONFIG = {
     "menubar": False,
     "statusbar": True,
     "height": 400,
+    "paste_block_drop": True,
+    "paste_as_text": True,
 }
 TINYMCE_SPELLCHECKER = False
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -22,7 +22,7 @@ django-upload-validator>=1.1.6,<1.2
 django-sri>=0.5.0,<0.6.0
 django-admin-interface>=0.24.1,<0.25
 django-maintenance-mode>=0.18.0,<0.19
-django-tinymce>=3.5.0,<3.6.0
+django-tinymce>=3.6.1,<3.7.0
 # django-filebrowser-no-grappelli==3.8.0
 # pyenchant==3.2.1
 gunicorn==20.1.0


### PR DESCRIPTION
- Updated TinyMCE package to 3.6.1
- Defined text to always be pasted as pure text